### PR TITLE
Add Multiplicative instances

### DIFF
--- a/src/Data/Group.purs
+++ b/src/Data/Group.purs
@@ -17,7 +17,6 @@ module Data.Group where
 import Data.Monoid (class Monoid)
 import Data.Monoid.Additive (Additive(..))
 import Data.Monoid.Dual (Dual(..))
-import Data.Monoid.Multiplicative (Multiplicative(..))
 import Data.Semigroup.Commutative (class Commutative)
 import Prelude
 
@@ -36,9 +35,6 @@ instance groupDual :: (Group g) => Group (Dual g) where
 
 instance groupAdditive :: (Ring r) => Group (Additive r) where
   ginverse (Additive x) = Additive (negate x)
-
-instance groupMultiplicative :: (DivisionRing r) => Group (Multiplicative r) where
-  ginverse (Multiplicative x) = Multiplicative (recip x)
 
 -- | An Abelian group is a group with a commutative operation.
 type Abelian a b = Group a => Commutative a => b

--- a/src/Data/Group.purs
+++ b/src/Data/Group.purs
@@ -17,6 +17,7 @@ module Data.Group where
 import Data.Monoid (class Monoid)
 import Data.Monoid.Additive (Additive(..))
 import Data.Monoid.Dual (Dual(..))
+import Data.Monoid.Multiplicative (Multiplicative(..))
 import Data.Semigroup.Commutative (class Commutative)
 import Prelude
 
@@ -35,6 +36,9 @@ instance groupDual :: (Group g) => Group (Dual g) where
 
 instance groupAdditive :: (Ring r) => Group (Additive r) where
   ginverse (Additive x) = Additive (negate x)
+
+instance groupMultiplicative :: (DivisionRing r) => Group (Multiplicative r) where
+  ginverse (Multiplicative x) = Multiplicative (recip x)
 
 -- | An Abelian group is a group with a commutative operation.
 type Abelian a b = Group a => Commutative a => b

--- a/src/Data/Semigroup/Commutative.purs
+++ b/src/Data/Semigroup/Commutative.purs
@@ -16,7 +16,7 @@ module Data.Semigroup.Commutative where
 
 import Data.Monoid.Additive (Additive)
 import Data.Monoid.Dual (Dual)
-import Data.Semigroup.Commutative (class Commutative)
+import Data.Monoid.Multiplicative (Multiplicative)
 import Prelude
 
 -- | A `Commutative` is a `Semigroup` with a commutative operation. Instances
@@ -31,4 +31,8 @@ instance commutativeUnit :: Commutative Unit
 
 instance commutativeDual :: (Commutative g) => Commutative (Dual g)
 
-instance commutativeAdditive :: (Ring r) => Commutative (Additive r)
+-- | Addition commutes for any `Semiring`
+instance commutativeAdditive :: (Semiring r) => Commutative (Additive r)
+
+-- | Multiplication commutes only for a `CommutativeRing`.
+instance commutativeMultiplicative :: (CommutativeRing r) => Commutative (Multiplicative r)


### PR DESCRIPTION
I was going through the hierarchies and noticed that `DivisionRing` should be able to provide `ginverse` for `Multiplicative`. (I think this is correct – we shouldn't need a full (commutative) field, but a field should furnish a commutative group I think.)

Also I relaxed `commutativeAdditive` to only need a `Semiring`. Addition is always commutative in the hierarchy so might as well require just the base class :)