### PR TITLE
loosen entailment for commutativeAdditive

### DIFF
--- a/src/Data/Semigroup/Commutative.purs
+++ b/src/Data/Semigroup/Commutative.purs
@@ -31,4 +31,4 @@ instance commutativeUnit :: Commutative Unit
 
 instance commutativeDual :: (Commutative g) => Commutative (Dual g)
 
-instance commutativeAdditive :: (Ring r) => Commutative (Additive r)
+instance commutativeAdditive :: Semiring r => Commutative (Additive r)


### PR DESCRIPTION
Only a semiring instance, not a ring, is required.